### PR TITLE
feat: update /gator:update skill to handle npx cache

### DIFF
--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -20,19 +20,42 @@ Update NavGator to the latest version.
    npm view @tyroneross/navgator version
    ```
 
-3. Compare versions. If already up to date, tell the user.
+3. Compare versions. If already up to date, tell the user and stop.
 
-4. If update available, install:
+4. If update available, update both the npx cache and global install (if present):
+
+   **Clear npx cache** so subsequent `npx` calls fetch the new version:
    ```bash
-   npm install -g @tyroneross/navgator@latest
+   # Find and remove the npx cached copy of navgator
+   NPX_CACHE_DIR=$(npm config get cache)/_npx
+   if [ -d "$NPX_CACHE_DIR" ]; then
+     find "$NPX_CACHE_DIR" -path "*/@tyroneross/navgator" -type d 2>/dev/null | head -1 | xargs -I{} dirname "$(dirname "{}")" | xargs rm -rf 2>/dev/null || true
+   fi
    ```
 
-5. Verify installation:
+   **Update global install** (if globally installed, so plugin symlinks stay current):
+   ```bash
+   if npm ls -g @tyroneross/navgator --depth=0 2>/dev/null | grep -q navgator; then
+     npm install -g @tyroneross/navgator@latest
+   fi
+   ```
+
+   **Pull latest via npx** to re-populate the cache:
+   ```bash
+   npx @tyroneross/navgator@latest --version
+   ```
+
+5. Verify the update:
    ```bash
    npx @tyroneross/navgator --version
    ```
 
 6. Report: "Updated NavGator from X.X.X to Y.Y.Y"
+
+## Notes
+
+- All gator skills invoke NavGator via `npx @tyroneross/navgator`. Clearing the npx cache ensures they pick up the new version immediately.
+- If the user has NavGator installed globally (for the plugin symlink), the global copy is also updated so the plugin stays in sync.
 
 ## Branding
 


### PR DESCRIPTION
All gator skills invoke NavGator via npx, but the update skill only
updated the global npm install. Now it also clears the npx cache and
re-populates it, so subsequent npx calls pick up the new version
immediately.

https://claude.ai/code/session_01V7YzLyK13SaENLMiupnUgq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved update instructions with better control flow and clearer messaging when the system is already up to date.
  * Enhanced the update process to properly handle both npx cache and global installations.
  * Added verification steps to confirm successful updates after completion.
  * New notes section provides guidance on cache management and global installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->