### PR TITLE
feat(scanner): emit uses-package edges for bare npm imports

### DIFF
--- a/src/__tests__/bare-imports.test.ts
+++ b/src/__tests__/bare-imports.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for bare-import (uses-package) edge emission in import-scanner.
+ *
+ * Validates that `import X from "pkg"` and `require("pkg")` in source files
+ * emit `uses-package` connections to matching npm package components.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { scanImports, KnownPackage } from '../scanners/connections/import-scanner.js';
+import type { ArchitectureConnection } from '../types.js';
+
+/**
+ * Build a temp project on disk with the given files, run scanImports against it,
+ * and return the resulting connections. Files are written under a unique tmp dir.
+ */
+async function runScan(
+  files: Record<string, string>,
+  knownPackages: KnownPackage[]
+): Promise<{
+  connections: Awaited<ReturnType<typeof scanImports>>['connections'];
+  components: Awaited<ReturnType<typeof scanImports>>['components'];
+  cleanup: () => void;
+}> {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'navgator-bare-'));
+  for (const [relPath, content] of Object.entries(files)) {
+    const abs = path.join(tmpRoot, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+  }
+  const sourceFiles = Object.keys(files);
+  const result = await scanImports(tmpRoot, sourceFiles, knownPackages);
+  return {
+    connections: result.connections,
+    components: result.components,
+    cleanup: () => fs.rmSync(tmpRoot, { recursive: true, force: true }),
+  };
+}
+
+function usesPackageEdges(connections: ArchitectureConnection[]): ArchitectureConnection[] {
+  return connections.filter((c) => c.connection_type === 'uses-package');
+}
+
+describe('bare-import edges (uses-package)', () => {
+  const knownPackages: KnownPackage[] = [
+    { name: 'react', component_id: 'COMP_npm_react_abc1' },
+    { name: '@radix-ui/react-dialog', component_id: 'COMP_npm_radix_abc2' },
+    { name: 'tailwindcss-animate', component_id: 'COMP_npm_tw_abc3' },
+    { name: 'drizzle-orm', component_id: 'COMP_db_drizzle_abc4' },
+  ];
+
+  let tmps: Array<() => void> = [];
+  afterAll(() => {
+    for (const cleanup of tmps) cleanup();
+  });
+
+  it('plain `import X from "react"` emits uses-package edge', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/app.ts': `import React from "react";\nexport const x = React;\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].to.component_id).toBe('COMP_npm_react_abc1');
+    expect(edges[0].code_reference.symbol).toBe('react');
+  });
+
+  it('scoped `import X from "@scope/pkg"` emits uses-package edge', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/dialog.tsx': `import * as Dialog from "@radix-ui/react-dialog";\nexport { Dialog };\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].to.component_id).toBe('COMP_npm_radix_abc2');
+    expect(edges[0].code_reference.symbol).toBe('@radix-ui/react-dialog');
+  });
+
+  it('scoped subpath `@scope/pkg/subpath` strips to @scope/pkg', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/dialog.tsx': `import { Root } from "@radix-ui/react-dialog/Root";\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].to.component_id).toBe('COMP_npm_radix_abc2');
+    expect(edges[0].code_reference.symbol).toBe('@radix-ui/react-dialog');
+  });
+
+  it('unscoped subpath `react/jsx-runtime` strips to react', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/jsx.ts': `import { jsx } from "react/jsx-runtime";\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].to.component_id).toBe('COMP_npm_react_abc1');
+    expect(edges[0].code_reference.symbol).toBe('react');
+  });
+
+  it('relative `./rel` import does NOT emit uses-package edge', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/a.ts': `import { b } from "./b";\nexport const x = b;\n`,
+        'src/b.ts': `export const b = 1;\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(0);
+  });
+
+  it('bare `require("pkg")` in tailwind.config.ts emits uses-package edge', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'tailwind.config.ts': `module.exports = {\n  plugins: [require("tailwindcss-animate")],\n};\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].to.component_id).toBe('COMP_npm_tw_abc3');
+    expect(edges[0].code_reference.symbol).toBe('tailwindcss-animate');
+  });
+
+  it('bare import of an UNKNOWN package is silently skipped (no ghost node)', async () => {
+    const { connections, components, cleanup } = await runScan(
+      {
+        'src/ghost.ts': `import "this-package-does-not-exist";\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(0);
+    // No component was invented for the unknown package
+    expect(components.find((c) => c.name === 'this-package-does-not-exist')).toBeUndefined();
+  });
+
+  it('multiple imports of same package from one file dedupe to a single edge', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/multi.tsx': [
+          `import React from "react";`,
+          `import { useState } from "react";`,
+          `import { jsx } from "react/jsx-runtime";`,
+          `export default React;`,
+        ].join('\n'),
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    // 3 source imports all resolve to `react` → one edge (deduped per-file)
+    expect(edges).toHaveLength(1);
+    expect(edges[0].to.component_id).toBe('COMP_npm_react_abc1');
+  });
+
+  it('dynamic import `import("pkg")` emits uses-package edge', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/lazy.ts': `async function load() { return await import("drizzle-orm"); }\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].to.component_id).toBe('COMP_db_drizzle_abc4');
+  });
+
+  it('re-export `export { X } from "pkg"` emits uses-package edge', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/reexport.ts': `export { default as React } from "react";\n`,
+      },
+      knownPackages
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].to.component_id).toBe('COMP_npm_react_abc1');
+  });
+
+  it('no knownPackages supplied → no uses-package edges emitted (backwards-compat)', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/a.ts': `import React from "react";\n`,
+      },
+      [] // empty
+    );
+    tmps.push(cleanup);
+
+    expect(usesPackageEdges(connections)).toHaveLength(0);
+  });
+
+  it('Node builtin `node:fs` is never emitted as uses-package', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/io.ts': `import * as fs from "node:fs";\nimport path from "node:path";\n`,
+      },
+      // Even if someone had a package named "fs" tracked, the node: prefix
+      // would exclude it from matching.
+      [...knownPackages, { name: 'fs', component_id: 'COMP_npm_fs_fake' }]
+    );
+    tmps.push(cleanup);
+
+    const edges = usesPackageEdges(connections);
+    expect(edges).toHaveLength(0);
+  });
+
+  it('plain `fs` builtin without node: prefix is silently skipped when not in knownPackages', async () => {
+    const { connections, cleanup } = await runScan(
+      {
+        'src/io.ts': `import * as fs from "fs";\n`,
+      },
+      knownPackages // no "fs" entry
+    );
+    tmps.push(cleanup);
+
+    expect(usesPackageEdges(connections)).toHaveLength(0);
+  });
+});

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -434,11 +434,23 @@ export async function scan(
     // File-level import graph (TS/JS local imports)
     if (options.verbose) console.log('  - Scanning file imports...');
     try {
-      const importResult = await scanImports(root, sourceFiles);
+      // Collect npm package components so bare imports (`import X from "react"`)
+      // can be resolved to the package component and emitted as `uses-package`
+      // edges. Use config_files filter instead of type filter: packages can be
+      // classified as 'npm' | 'framework' | 'database' | 'service' depending
+      // on FRAMEWORK_SIGNATURES, but all originate from a package.json.
+      const knownPackages = allComponents
+        .filter(c => c.source.config_files?.some(f =>
+          f === 'package.json' || f.endsWith('/package.json')
+        ))
+        .map(c => ({ name: c.name, component_id: c.component_id }));
+
+      const importResult = await scanImports(root, sourceFiles, knownPackages);
       allComponents.push(...importResult.components);
       allConnections.push(...importResult.connections);
       if (options.verbose) {
-        console.log(`    Found ${importResult.components.length} internal modules, ${importResult.connections.length} file-level imports`);
+        const usesPkgCount = importResult.connections.filter(c => c.connection_type === 'uses-package').length;
+        console.log(`    Found ${importResult.components.length} internal modules, ${importResult.connections.length} file-level imports (${usesPkgCount} uses-package)`);
       }
 
       // SCIP overlay (T11): when --scip / NAVGATOR_SCIP=1, run the

--- a/src/scanners/connections/import-scanner.ts
+++ b/src/scanners/connections/import-scanner.ts
@@ -31,6 +31,15 @@ const ES_REEXPORT_REL_RE = /export\s+(?:\{[^}]*\}|\*)\s+from\s+['"](\.\/[^'"]+)[
 const REQUIRE_REL_RE = /require\s*\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
 const DYNAMIC_IMPORT_REL_RE = /import\s*\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
 
+// Bare specifier patterns — npm package imports (NOT relative, NOT alias).
+// Captures anything not starting with ./ ../ @/ ~/ — includes @scope/name and bare names.
+// Excludes node: protocol (built-ins) and data: / http: protocols.
+const BARE_SPEC = `(?!\\.\\.?\\/|@\\/|~\\/|node:|data:|http:|https:|file:)([a-zA-Z0-9@][a-zA-Z0-9@_./-]*)`;
+const ES_IMPORT_BARE_RE = new RegExp(`import\\s+(?:[\\s\\S]*?\\s+from\\s+)?['\"]${BARE_SPEC}['\"]`, 'g');
+const ES_REEXPORT_BARE_RE = new RegExp(`export\\s+(?:\\{[^}]*\\}|\\*(?:\\s+as\\s+\\w+)?)\\s+from\\s+['\"]${BARE_SPEC}['\"]`, 'g');
+const REQUIRE_BARE_RE = new RegExp(`require\\s*\\(\\s*['\"]${BARE_SPEC}['\"]\\s*\\)`, 'g');
+const DYNAMIC_IMPORT_BARE_RE = new RegExp(`import\\s*\\(\\s*['\"]${BARE_SPEC}['\"]\\s*\\)`, 'g');
+
 // Map .js/.jsx extensions to their TypeScript equivalents
 // (TS convention: `import './foo.js'` resolves to `./foo.ts`)
 const JS_TO_TS: [string, string][] = [
@@ -180,6 +189,46 @@ function extractImports(content: string): string[] {
 }
 
 /**
+ * Extract bare package specifiers from file content.
+ * Returns raw specifiers before subpath stripping (e.g. "react/jsx-runtime").
+ */
+function extractBareImports(content: string): string[] {
+  const specifiers: string[] = [];
+  const patterns = [
+    ES_IMPORT_BARE_RE, ES_REEXPORT_BARE_RE, REQUIRE_BARE_RE, DYNAMIC_IMPORT_BARE_RE,
+  ];
+
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      if (match[1]) specifiers.push(match[1]);
+    }
+  }
+
+  return [...new Set(specifiers)];
+}
+
+/**
+ * Strip subpath from a bare specifier to get the package root.
+ *   "react"                       → "react"
+ *   "react/jsx-runtime"           → "react"
+ *   "@radix-ui/react-dialog"      → "@radix-ui/react-dialog"
+ *   "@radix-ui/react-dialog/Root" → "@radix-ui/react-dialog"
+ */
+function stripSubpath(specifier: string): string {
+  if (specifier.startsWith('@')) {
+    // Scoped package: keep first two segments
+    const parts = specifier.split('/');
+    if (parts.length < 2) return specifier;
+    return `${parts[0]}/${parts[1]}`;
+  }
+  // Unscoped: keep first segment
+  const idx = specifier.indexOf('/');
+  return idx === -1 ? specifier : specifier.slice(0, idx);
+}
+
+/**
  * Find the line number where a specifier appears in the content.
  */
 function findImportLine(content: string, specifier: string): number {
@@ -248,13 +297,29 @@ function buildFileComponent(file: string, timestamp: number): ArchitectureCompon
 }
 
 /**
+ * A minimal shape used to resolve bare imports to npm package components.
+ * Callers pass { name, component_id } pairs — typically the npm-type components
+ * produced by `scanNpmPackages`.
+ */
+export interface KnownPackage {
+  name: string;
+  component_id: string;
+}
+
+/**
  * Scan source files and build file-level import connections.
  * Accepts the already-discovered source file list from the main scanner
  * to avoid redundant glob and ensure consistent file coverage.
+ *
+ * When `knownPackages` is provided, bare imports (e.g. `import X from "react"`)
+ * are emitted as `uses-package` edges from the source file component to the
+ * matching npm package component. Bare specifiers with no matching known
+ * package are skipped silently (no ghost nodes).
  */
 export async function scanImports(
   projectRoot: string,
-  sourceFiles?: string[]
+  sourceFiles?: string[],
+  knownPackages?: KnownPackage[]
 ): Promise<ScanResult> {
   const components: ArchitectureComponent[] = [];
   const connections: ArchitectureConnection[] = [];
@@ -287,6 +352,17 @@ export async function scanImports(
   const knownFiles = new Set(files);
   const now = Date.now();
   const componentIdByFile = new Map<string, string>();
+
+  // Build a Map<packageName, component_id> for O(1) bare-import resolution.
+  // Only populated when caller provided knownPackages; otherwise bare-import
+  // edges are not emitted (backwards-compatible with callers that don't pass
+  // the package list).
+  const packageIdByName = new Map<string, string>();
+  if (knownPackages) {
+    for (const pkg of knownPackages) {
+      packageIdByName.set(pkg.name, pkg.component_id);
+    }
+  }
 
   for (const file of files) {
     const component = buildFileComponent(file, now);
@@ -346,6 +422,46 @@ export async function scanImports(
           timestamp: now,
           last_verified: now,
         });
+      }
+
+      // Bare-package edges: `import X from "react"` → file uses-package react.
+      // Only emitted when the caller provided a knownPackages set; bare
+      // specifiers that don't match a known package are skipped silently
+      // (no ghost nodes).
+      if (packageIdByName.size > 0) {
+        const bareSpecs = extractBareImports(content);
+        const emitted = new Set<string>(); // dedupe per-file: one edge per package
+        for (const rawSpec of bareSpecs) {
+          const pkgName = stripSubpath(rawSpec);
+          const targetId = packageIdByName.get(pkgName);
+          if (!targetId) continue;
+          if (emitted.has(pkgName)) continue;
+          emitted.add(pkgName);
+
+          const line = findImportLine(content, rawSpec);
+          connections.push({
+            connection_id: generateConnectionId('uses-package'),
+            from: {
+              component_id: componentIdByFile.get(file) || `FILE:${file}`,
+              location: { file, line },
+            },
+            to: {
+              component_id: targetId,
+            },
+            connection_type: 'uses-package',
+            code_reference: {
+              file,
+              symbol: pkgName,
+              symbol_type: 'import',
+              line_start: line,
+            },
+            description: `${file} uses ${pkgName}`,
+            detected_from: 'import-scanner (bare)',
+            confidence: 1.0,
+            timestamp: now,
+            last_verified: now,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- New `uses-package` connection type linking source files to the npm packages they actually import
- Adds bare-import regex pass to `import-scanner.ts` (plain, scoped, subpath-stripped, `node:` builtin exclusion, per-file dedupe)
- Works for `import`, `require()`, dynamic `import()`, and re-exports — including `require()` in `tailwind.config.ts` / `postcss.config.*`
- `knownPackages: Set<string>` built from `npm.ts` output gates emission — unknown specifiers are silently skipped, no ghost nodes

## Why
Today `import React from "react"` emits no edge (scanner intentionally skips bare specifiers). Every npm package ends up orphaned regardless of use. On the ProductPilot fixture this meant `dead` reported 70 "dead" packages when only 15 were actually unused.

## Validation against ProductPilot fixture
| Metric | Before | After |
|---|---|---|
| Dead orphans | 70 | **15** (-78.6%) |
| Connections | 264 | 453 (+189) |
| `uses-package` edges | 0 | 189 |
| Scan duration | ~500ms | ~500ms (flat) |

Remaining 15 orphans are legitimate toolchain / `@types/*` / infra markers — all grep-confirmed unused or type-only. Further reductions would come from research changes #3 (`@types/*` classification) and #4 (shadcn passthrough), tracked in the report thread.

## Tests
- `__tests__/bare-imports.test.ts` — 13 new cases: plain, scoped, scoped-subpath-strip, unscoped-subpath-strip, relative negative, config `require()`, unknown-package negative (no ghost), per-file dedupe, dynamic import, re-export, `node:` builtin exclusion, plain builtin exclusion, backwards-compat when `knownPackages` omitted
- Full suite: **303/303 pass**

## Test plan
- [x] `npm run test` — 303/303 pass
- [x] `npm run build:cli` — clean
- [x] Re-scan ProductPilot (both committed state and live working tree with in-progress secret-encryption feature) — dead count stable at 15, scan duration flat, `node:crypto` correctly excluded
- [ ] Maintainer review of new regex patterns and `stripSubpath` helper edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection and tracking of npm package dependencies, recognizing various import syntaxes including ES imports, CommonJS requires, re-exports, and dynamic imports.

* **Tests**
  * Added comprehensive test suite validating bare import detection, including scoped packages, subpath normalization, and proper exclusion of relative imports and unknown packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->